### PR TITLE
Add generic health files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+Thank you for wanting to contribute.
+
+To help out, you can:
+
+- open new issues about your ideas for making the project better
+- get involved in any open issue or pull request
+- improve the documentation
+
+## Code contributions
+
+To start coding, you'll need:
+
+- a minimum of [Node.js](https://nodejs.org/en/) v10, though we do recommend using the latest LTS release
+- the latest [npm](https://www.npmjs.com/)
+
+Then:
+
+1. [Fork and clone](https://guides.github.com/activities/forking/) the repository.
+2. Install all the dependencies with `npm ci`.
+
+### Open a pull request
+
+When you have something to share, it's time to [open a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
+
+After we review and merge your pull request, we'll invite you to become a maintainer of the stylelint organization. You'll then be able to help manage issues, pull requests and releases. You'll also be able to work on the organizations repositories rather than your forks.
+
+## Financial contributions
+
+We welcome financial contributions in full transparency on our [Open Collective](https://opencollective.com/stylelint).
+
+Anyone can file an expense. We will "merge" the expense into the ledger if it makes sense for the development of the community. Open Collective then reimburses the person who filed the expense.
+
+You can financially support us by becoming a:
+
+- [backer](https://opencollective.com/stylelint#backer)
+- [sponsor](https://opencollective.com/stylelint#sponsor)

--- a/.github/ISSUE_TEMPLATE/REPORT_A_BUG.md
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_BUG.md
@@ -7,61 +7,16 @@ about: "Is something not working as you expect?"
 
 > Clearly describe the bug
 
-e.g. "There are false positives for two leading zeros when ..."
+...
 
-> Which rule, if any, is the bug related to?
+> What steps are needed to reproduce the bug?
 
-e.g. `number-leading-zero`
-
-> What CSS is needed to reproduce the bug?
-
-e.g.
-
-```css
-a {
-  width: 00.1em;
-}
-```
-
-> What configuration is needed to reproduce the bug?
-
-e.g.
-
-```json
-{
-  "rules": {
-    "number-leading-zero": "always"
-  }
-}
-```
-
-> Which version of stylelint are you using?
-
-e.g. `9.2.0`
-
-> How are you running stylelint: CLI, PostCSS plugin, Node.js API?
-
-e.g. "CLI with `stylelint "**/*.css" --config myconfig.json`"
-
-> Does the bug relate to non-standard syntax (e.g. SCSS, Less etc.)?
-
-e.g. "Yes, it's related to SCSS nested properties."
+...
 
 > What did you expect to happen?
 
-e.g. "No warnings to be flagged."
+...
 
 > What actually happened (e.g. what warnings or errors did you get)?
 
-e.g. "The following warnings were flagged:"
-
-```shell
-test.css
-2:4    Expected a leading zero (number-leading-zero)
-```
-
-<!--
-You can help us fix the bug more quickly by:
-1. Figuring out what needs doing and proposing it.
-2. Writing the code and submitting a PR once the bug is confirmed.
--->
+...

--- a/.github/ISSUE_TEMPLATE/REPORT_A_DOCS_ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_DOCS_ISSUE.md
@@ -7,8 +7,8 @@ about: "Is something wrong, confusing or missing in the docs?"
 
 > Clearly describe the documentation issue
 
-e.g. "The description of the `ignoreFiles` option is confusing ..."
+...
 
 > What solution would you like to see?
 
-e.g. "I suggest rewriting it as ..."
+...

--- a/.github/ISSUE_TEMPLATE/REQUEST_A_FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/REQUEST_A_FEATURE.md
@@ -1,20 +1,14 @@
 ---
 name: "\U0001F680 Request a feature"
-about: "Do you want to suggest a new feature, rule or option?"
+about: "Do you want to suggest a new feature?"
 ---
 
 <!-- Please answer the following. We close issues that don't. -->
 
 > What is the problem you're trying to solve?
 
-e.g. "The developers on my team use inconsistent values for media queries. This adds unnecessary complexity and ... "
+...
 
 > What solution would you like to see?
 
-e.g. "A new rule that ..."
-
-<!--
-You can help us add the feature more quickly by:
-1. Providing as much detail as possible in this issue.
-2. Writing the code and submitting a PR once the feature is approved.
--->
+...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,6 @@
-<!---
-Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.
+<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->
 
-If an issue exists, please continue by answering these two questions:  -->
+<!-- Please answer the following. We close pull requests that don't. -->
 
 > Which issue, if any, is this issue related to?
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,8 @@
+# Support
+
+Post your query on [Stack Overflow](https://stackoverflow.com/questions/tagged/stylelint).
+
+Only create a new issue if you:
+
+- think you've found a bug
+- have a feature request


### PR DESCRIPTION
The main repository will still use bespoke health files for:

- issues
- contributing
- support

And the vscode repository for just issues.

I suspect all the other repositories will be fine with using all these generic health files.