### PR TITLE
Improve reusable `lint` and `test` workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,9 @@ jobs:
 
     runs-on: ${{ inputs.os }}
 
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -45,4 +48,4 @@ jobs:
         run: npm ci
 
       - name: Test
-        run: npm test
+        run: npm test --ignore-scripts


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR includes the followings:

- restrict `permissions`
- run only tests via `npm test`
  - If `npm run pretest` run lint, it should be useful that `npm test` runs only tests without linting

