### PR TITLE
Remove Node.js 12 from CI testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       node-version:
         description: Node.js version
         required: false
-        default: '["12", "14", "16", "18"]'
+        default: '["14", "16", "18"]'
         type: string
       os:
         description: OS name
@@ -42,8 +42,7 @@ jobs:
           cache: npm
 
       - name: Install latest npm
-        # TODO: npm@9 is the latest, but it doesn't work on Node.js v12 and v14 with windows.
-        run: npm install --global npm@8
+        run: npm install --global npm@latest
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
+      # HACK: See https://github.com/npm/cli/issues/4341
+      - name: Workaround for npm installation failure on Node.js 14 and Windows
+        if: ${{ startsWith(matrix.node-version, '14') && startsWith(matrix.os, 'windows') }}
+        run: npm install --global npm@8.3
+
       - name: Install latest npm
         run: npm install --global npm@latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm install --global npm@8.3
 
       - name: Install latest npm
-        run: npm install --global npm@latest
+        run: npm install --global npm@latest && npm --version
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

- Closes #14 
- Closes #13 

> Is there anything in the PR that needs further explanation?

This pull request is blocked until stylelint/stylelint completely removes Node.js 12.
See also https://github.com/stylelint/stylelint/pull/6477
