### PR TITLE
Add `exclude` input to test reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,6 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
     with:
+      node-version: '["16", "18"]'
       os: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      exclude: '[{"node-version": "16", "os": "windows-latest"}]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: '["ubuntu-latest"]'
         type: string
+      exclude:
+        description: Exclude from matrix
+        required: false
+        default: '[]'
+        type: string
 
 jobs:
   test:
@@ -25,6 +30,7 @@ jobs:
         #       For details, see https://github.community/t/reusable-workflow-with-strategy-matrix/205676/2
         node-version: ${{ fromJson(inputs.node-version) }}
         os: ${{ fromJson(inputs.os) }}
+        exclude: ${{ fromJson(inputs.exclude) }}
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ jobs:
     # with:
     #   node-version: '["16", "18"]'
     #   os: '["ubuntu-latest", "windows-latest"]'
+    #   exclude: '[{"node-version": "16", "os": "windows-latest"}]'
 ```


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Is there anything in the PR that needs further explanation?

The new input will be set to `strategy.matrix.exclude`.
See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations
