### PR TITLE
Create `.github/dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: monthly


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Dependabot now supports reusable workflows for GitHub Actions.
See https://github.blog/changelog/2023-03-13-dependabot-updates-support-reusable-workflows-for-github-actions/

For example, our testing workflow now uses `actions/checkout@v3` and `actions/setup-node@v3`:

https://github.com/stylelint/.github/blob/442136ab28e411a3f3489737889988b9121d274d/.github/workflows/test.yml#L41-L45

When these actions are updated, Dependabot will create PRs instead of us.