### PR TITLE
Fix: add timeouts for GitHub Workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,8 @@ jobs:
     permissions:
       contents: read
 
+    timeout-minutes: 30
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
     permissions:
       contents: read
 
+    timeout-minutes: 30
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See : https://github.com/stylelint/stylelint/issues/6880

> Is there anything in the PR that needs further explanation?


CI for Stylelint seems to take ±6 minutes on most runs, sometimes a little bit over 10 minutes.

30 minutes seems like a safe multiple of the current duration.
Sufficient headroom so that no one will ever encounter this timeout during normal operations.

I am making the assumption that the Stylelint repo has the most complex and extensive test suite and is the consumer of these workflows that takes the longest to complete.

