### PR TITLE
Support npm v10 on test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,13 @@ jobs:
         if: ${{ startsWith(matrix.node-version, '14') && startsWith(matrix.os, 'windows') }}
         run: npm install --global npm@8.3
 
+      # NOTE: npm v10 has dropped support for Node.js v16.
+      - name: Install npm v9
+        if: ${{ startsWith(matrix.node-version, '16') || startsWith(matrix.node-version, '14') }}
+        run: npm install --global npm@9 && npm --version
+
       - name: Install latest npm
+        if: ${{ !startsWith(matrix.node-version, '16') && !startsWith(matrix.node-version, '14') }}
         run: npm install --global npm@latest && npm --version
 
       - name: Install dependencies


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

npm v10 has dropped support for Node.js v16. So we need to use npm v9 on Node.js v16 or lower.
See https://github.com/npm/cli/releases/tag/v10.0.0
