### PR TITLE
Update labels via `github-label-sync`

### DIFF
--- a/labels.json
+++ b/labels.json
@@ -20,21 +20,6 @@
     "color": "0366d6"
   },
   {
-    "name": "pr: needs documentation",
-    "description": "needs documentation adding by the author",
-    "color": "2678BA"
-  },
-  {
-    "name": "pr: needs revision",
-    "description": "needs revision by the author",
-    "color": "D34617"
-  },
-  {
-    "name": "pr: needs tests",
-    "description": "needs tests adding by author",
-    "color": "CA2BAF"
-  },
-  {
     "name": "priority: high",
     "description": "is impactful on users",
     "color": "ffbf11"

--- a/labels.json
+++ b/labels.json
@@ -6,7 +6,7 @@
   },
   {
     "name": "help wanted",
-    "description": "is difficult and help is wanted",
+    "description": "is likely non-trival and help is wanted",
     "color": "b60205"
   },
   {
@@ -65,9 +65,14 @@
     "color": "5a18a5"
   },
   {
-    "name": "status: ask to implement",
+    "name": "status: ready to implement",
     "description": "is ready to be worked on by someone",
     "color": "008672"
+  },
+  {
+    "name": "status: ask to implement",
+    "description": "ask before implementing as may no longer be relevant",
+    "color": "A6E4D9"
   },
   {
     "name": "status: wip",
@@ -76,7 +81,7 @@
   },
   {
     "name": "type: bug",
-    "description": "a problem with a feature",
+    "description": "a problem with a feature or rule",
     "color": "f9d0c4"
   },
   {
@@ -86,7 +91,7 @@
   },
   {
     "name": "type: enhancement",
-    "description": "a new feature",
+    "description": "a new feature that isn't related to rules",
     "color": "d4c5f9"
   },
   {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref stylelint/stylelint#7459

> Is there anything in the PR that needs further explanation?

We've added the "ask to implement" label in the `stylelint/stylelint` repository.

When syncing labels by this PR's `labels.json`, there are a few differences. Should they be removed?

```sh-session
$ npx github-label-sync "stylelint/stylelint" --dry-run --allow-added-labels
Syncing labels for "stylelint/stylelint"
Validating provided labels
Fetching labels from GitHub
 > Missing: the "pr: needs documentation" label is missing from the repo. It will be created.
 > Missing: the "pr: needs revision" label is missing from the repo. It will be created.
 > Missing: the "pr: needs tests" label is missing from the repo. It will be created.
This is a dry run. No changes have been made on GitHub
```
