### PR TITLE
Use Bash on all OS environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,11 @@ jobs:
     with:
       node-version: '["16", "18", "20", "22"]'
       os: '["ubuntu-latest", "windows-latest", "macos-latest"]'
-      exclude: '[{"node-version": "22", "os": "windows-latest"}]'
+      exclude: |
+        [
+          {"node-version": "18", "os": "ubuntu-latest"},
+          {"node-version": "20", "os": "ubuntu-latest"}
+        ]
       test-options: 'foo bar'
 
   test-default:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,12 @@ jobs:
 
     timeout-minutes: 30
 
+    # HACK: The `npm` command fails on Node.js v22 and Windows OS for unknown error. So, this always uses Bash.
+    # See https://github.com/stylelint/.github/pull/35/commits/6f7dc8bd7b597902920c9b571f06fbcce69d0c72
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See #35

> Is there anything in the PR that needs further explanation?

This aims to prevent the following error on Node.js v22 and Windows:

```
node:internal/modules/cjs/loader:1205
  throw err;
  ^

Error: Cannot find module 'C:\npm\prefix\node_modules\npm\bin\npm-cli.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1202:15)
    at Module._load (node:internal/modules/cjs/loader:1027:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:187:14)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v22.0.0
```

See https://github.com/stylelint/.github/pull/35/commits/6f7dc8bd7b597902920c9b571f06fbcce69d0c72
