### PR TITLE
Avoid installing npm v11 on Node.js v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,13 @@ jobs:
           npm install --global npm@9
           echo "npm: $(npm --version)"
 
+      # NOTE: npm v11 has dropped support for Node.js v18.
+      - name: Install npm v10
+        if: ${{ startsWith(steps.node-version.outputs.value, 'v18') }}
+        run: |
+          npm install --global npm@10
+          echo "npm: $(npm --version)"
+
       - name: Install latest npm
         if: ${{ !startsWith(steps.node-version.outputs.value, 'v16') }}
         run: |


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #39

> Is there anything in the PR that needs further explanation?

npm v11 has dropped the support for Node.js v18.

```sh-session
$ npm v npm@11.0.0 engines
{ node: '^20.17.0 || >=22.9.0' }
```

So, this change tries installing npm v10 instead.
