### PR TITLE
Add permissions explicitly to all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
   workflow_dispatch:
 
-permissions: {} # disable all by default
+permissions: read-all # Default. Each job can override this.
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
   workflow_dispatch:
 
+permissions: {} # disable all by default
+
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       node-version: ${{ steps.init-node-version.outputs.node-version }}
+    permissions: {} # disable all
     steps:
       - name: Initialize "node-version" parameter
         id: init-node-version


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Having explicit permissions in GitHub Actions workflows is a good practice for security.
E.g., CodeQL detects an issue, https://github.com/stylelint/.github/security/code-scanning/1

For details, see also the document below:
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs
