### PR TITLE
Add support for Node.js 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       node-version:
         description: Node.js version
         required: false
-        default: '["18", "20", "22"]'
+        default: '["18", "20", "22", "24"]'
         type: string
       node-version-file:
         description: Node.js version file


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

On May 6, 2025, Node.js v24 was released:
https://nodejs.org/en/blog/release/v24.0.0

The 24.x versions have the **Current** status now.
Ref https://github.com/nodejs/Release#release-schedule
