### PR TITLE
Drop support for Node.js v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
     with:
-      node-version: '["16", "18", "20", "22"]'
+      node-version: '["22", "24"]'
       os: '["ubuntu-latest", "windows-latest", "macos-latest"]'
       exclude: |
         [
-          {"node-version": "18", "os": "ubuntu-latest"},
-          {"node-version": "20", "os": "ubuntu-latest"}
+          {"node-version": "22", "os": "windows-latest"},
+          {"node-version": "24", "os": "macos-latest"}
         ]
       test-options: 'foo bar'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       node-version:
         description: Node.js version
         required: false
-        default: '["18", "20", "22", "24"]'
+        default: '["20", "22", "24"]' # https://endoflife.date/nodejs
         type: string
       node-version-file:
         description: Node.js version file


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Node.js v18 is already EOL.
Ref https://endoflife.date/nodejs
