### PR TITLE
Update CODEOWNERS to include `package.json`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,7 @@
 # https://help.github.com/articles/about-codeowners/
 
-# All proposed file changes under the `.github/` folder must be approved by the stylelint owners team prior to merging 
+# All proposed file changes under the `.github/` folder must be approved by the owners team prior to merging.
 .github/ @stylelint/owners
+
+# Require approvals by the owners team when updating dependencies or package metadata.
+package.json @stylelint/owners


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

`package.json` can contain critical dependencies or package metadata (especially about publishing), so I believe requiring approvals by owners makes sense.
