### PR TITLE
Fix `release` workflow due to missing `id-token` permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,3 +12,4 @@ jobs:
       publish: false
     permissions:
       contents: write
+      id-token: write


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to PR #50 

> Is there anything in the PR that needs further explanation?

This aims to resolve the following error:

```
The workflow is not valid. .github/workflows/release.yml (Line: 9, Col: 3): Error calling workflow
'stylelint/.github/.github/workflows/call-release.yml@f6f83da0246a63aa6ce365811c23609098207351'.
The nested job 'release' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

https://github.com/stylelint/.github/actions/runs/18088033133

See also:
https://github.com/stylelint/.github/blob/f6f83da0246a63aa6ce365811c23609098207351/.github/workflows/call-release.yml#L24