### PR TITLE
Fix `release-pr` workflow due to GitHub API error

### DIFF
--- a/.github/workflows/call-release-pr.yml
+++ b/.github/workflows/call-release-pr.yml
@@ -90,7 +90,7 @@ jobs:
           if [[ "${PKG_PRIVATE}" != "true" ]]; then
             NPM_PACKAGE_URL="<https://www.npmjs.com/package/${PKG_NAME}>"
           else
-            NPM_PACKAGE_URL="*N/A*"
+            NPM_PACKAGE_URL="N/A"
           fi
           echo "${NPM_PACKAGE_URL}"
 

--- a/.github/workflows/call-release-pr.yml
+++ b/.github/workflows/call-release-pr.yml
@@ -75,6 +75,7 @@ jobs:
           git push origin "${BRANCH_NAME}"
 
           # Construct a changes URL
+          echo -n "Constructing a changes URL... "
           LATEST_TAG=$(gh release list --limit 1 --json 'tagName' --jq '.[0].tagName')
           if [[ -n "${LATEST_TAG}" ]]; then
             CHANGES_FROM="${LATEST_TAG}"
@@ -82,13 +83,16 @@ jobs:
             CHANGES_FROM='@{1year}'
           fi
           CHANGES_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${CHANGES_FROM}...${BRANCH_NAME}"
+          echo "${CHANGES_URL}"
 
-          # Construct npm package URL if it is not private
+          # Construct a npm package URL if it is not private
+          echo -n "Constructing a npm package URL... "
           if [[ "${PKG_PRIVATE}" != "true" ]]; then
             NPM_PACKAGE_URL="<https://www.npmjs.com/package/${PKG_NAME}>"
           else
             NPM_PACKAGE_URL="*N/A*"
           fi
+          echo "${NPM_PACKAGE_URL}"
 
           # Prepare PR body
           PR_BODY_FILE="${RUNNER_TEMP}/pr_body.txt"
@@ -102,6 +106,7 @@ jobs:
           - [ ] Quickly review the changes on the URL above.
           - [ ] The new version is expected.
           - [ ] The CHANGELOG.md is expected. If necessary, update it.
+          - [ ] Request a review from the owners team.
 
           If the PR is approved and all checks have passed, you can merge it.
           Then, the release will be automatically started.
@@ -111,12 +116,12 @@ jobs:
           EOF
 
           # Create PR
+          echo "Creating a pull request..."
           gh pr create \
             --head "${BRANCH_NAME}" \
             --title "${COMMIT_MESSAGE}" \
             --body-file "${PR_BODY_FILE}" \
-            --assignee "${GITHUB_ACTOR}" \
-            --reviewer '@stylelint/owners' # Explicitly request review from the owners team
+            --assignee "${GITHUB_ACTOR}"
 
           # Show PR URL
           PR_URL=$(gh pr view --json 'url' --jq '.url')


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to PR #50

> Is there anything in the PR that needs further explanation?

This fixes the following error:

```
error fetching organization teams: GraphQL: Resource not accessible by integration (organization.teams)
```

https://github.com/stylelint/.github/actions/runs/18088378247/job/51463357782#step:7:76

The cause is that the used API token cannot access the organization's teams.
So, this removes the `--reviewer` option from the `gh pr create` command.

In addition, this prints some progress information to logs.
