### PR TITLE
Leave tag creation to `stylelint/changelog-to-github-release-action` on release

### DIFF
--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -38,6 +38,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Get version
+        id: get-version
+        env:
+          PR_HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          # Check if the package version matches the branch name
+          PKG_VERSION=$(jq -r '.version' package.json)
+          if [[ "${PR_HEAD_BRANCH}" == "release/${PKG_VERSION}" ]]; then
+            echo "version=${PKG_VERSION}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::error::The version '${PKG_VERSION}' in package.json does not match the version in the branch name '${PR_HEAD_BRANCH}'."
+            exit 1
+          fi
+
       - name: Set up Node.js LTS
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
@@ -50,25 +64,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Create tag
-        id: create-tag
-        env:
-          PR_HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: |
-          # Check if the package version matches the branch name
-          PKG_VERSION=$(jq -r '.version' package.json)
-          if [[ "${PR_HEAD_BRANCH}" != "release/${PKG_VERSION}" ]]; then
-            echo "::error::The version '${PKG_VERSION}' in package.json does not match the version in the branch name '${PR_HEAD_BRANCH}'."
-            exit 1
-          fi
-
-          # Create and push tag
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
-          git tag "${PKG_VERSION}"
-          git push origin "${PKG_VERSION}"
-          echo "new-tag=${PKG_VERSION}" >> "${GITHUB_OUTPUT}"
-
       - name: Publish to npm registry
         if: ${{ inputs.publish }}
         run: |
@@ -79,5 +74,5 @@ jobs:
       - name: Create GitHub release
         uses: stylelint/changelog-to-github-release-action@8526eab6046b8f5b2f883844d953b5eb6f80e674 # 0.5.1
         with:
-          tag: ${{ steps.create-tag.outputs.new-tag }}
+          tag: ${{ steps.get-version.outputs.version }}
           draft: true

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To perform releasing in a repository with the shareable workflows, take the foll
 
 Prerequisites:
 
+- Must follow the release branch name pattern `release/{version}`, e.g., `release/1.0.0`.
 - Must import the branch and tag [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets).
 - Must set up the `npm` [environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments).
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

I found that the `git tag` step is no longer necessaryin the `call-release.yml` workflow because the `stylelint/changelog-to-github-release-action` action already handles tag creation. By removing this step, we can streamline the workflow and avoid redundant operations.
