### PR TITLE
Add `node-version` input to `call-release` and `call-release-pr` workflows

### DIFF
--- a/.github/workflows/call-release-pr.yml
+++ b/.github/workflows/call-release-pr.yml
@@ -7,6 +7,11 @@ on:
         description: New version to release
         required: true
         type: string
+      node-version:
+        description: Node.js version
+        required: false
+        default: 'lts/*'
+        type: string
 
 jobs:
   release-pr:
@@ -33,10 +38,10 @@ jobs:
         with:
           fetch-depth: 0 # Commit history may be required, such as changelog generation etc.
 
-      - name: Set up Node.js LTS
+      - name: Set up Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 'lts/*'
+          node-version: ${{ inputs.node-version }}
 
       - name: Install latest npm
         run: npm install --global npm@latest

--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: true
         type: boolean
+      node-version:
+        description: Node.js version
+        required: false
+        default: 'lts/*'
+        type: string
 
 jobs:
   release:
@@ -52,10 +57,10 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Node.js LTS
+      - name: Set up Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 'lts/*'
+          node-version: ${{ inputs.node-version }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install latest npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added: `node-version` input to `call-release` and `call-release-pr` workflows.
+
 ## 0.1.1 - 2025-10-01
 
 - Fixed: `call-release` workflow to leave tag creation to `stylelint/changelog-to-github-release-action`.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

There is a workflow client that wants to use a non-LTS Node.js version.

E.g. https://github.com/stylelint/changelog-to-github-release-action/actions/runs/18153408568/job/51668225341