### PR TITLE
Fix incorrect `new-version`/`new-version-command` input references in `call-release-pr` workflow

### DIFF
--- a/.github/workflows/call-release-pr.yml
+++ b/.github/workflows/call-release-pr.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Bump version in package.json
         id: bump-version
         env:
-          NEW_VERSION: ${{ github.event.inputs.new-version }}
-          NEW_VERSION_COMMAND: ${{ github.event.inputs.new-version-command }}
+          NEW_VERSION: ${{ inputs.new-version }}
+          NEW_VERSION_COMMAND: ${{ inputs.new-version-command }}
         run: |
           # Set a new version if a command is provided
           if [[ -n "${NEW_VERSION_COMMAND}" ]]; then

--- a/.github/workflows/call-release-pr.yml
+++ b/.github/workflows/call-release-pr.yml
@@ -63,6 +63,9 @@ jobs:
         env:
           NEW_VERSION: ${{ inputs.new-version }}
           NEW_VERSION_COMMAND: ${{ inputs.new-version-command }}
+          # Set the environment variables below for `new-version-command` that needs any GitHub token.
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           # Set a new version if a command is provided
           if [[ -n "${NEW_VERSION_COMMAND}" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed: incorrect `new-version`/`new-version-command` input references in `call-release-pr` workflow.
+
 ## 0.3.0 - 2025-10-01
 
 - Added: `new-version-command` input to `call-release-pr` workflow.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
