### PR TITLE
Add `call-dependency-review` callable workflow

### DIFF
--- a/.github/workflows/call-dependency-review.yml
+++ b/.github/workflows/call-dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review (callable)
+
+on:
+  workflow_call:
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/call-dependency-review.yml
+++ b/.github/workflows/call-dependency-review.yml
@@ -16,3 +16,5 @@ jobs:
 
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-scopes: runtime, development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  push:
+  pull_request:
   workflow_dispatch:
 
 permissions: read-all # Default. Each job can override this.
@@ -31,4 +31,5 @@ jobs:
       node-version-file: .node-version
 
   dependency-review:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/call-dependency-review.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
     uses: ./.github/workflows/call-test.yml
     with:
       node-version-file: .node-version
+
+  dependency-review:
+    uses: ./.github/workflows/call-dependency-review.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added: `call-dependency-review` callable workflow.
+
 ## 0.6.1 - 2026-03-31
 
 - Fixed: `MODULE_NOT_FOUND` error on globally updating npm from `10.9.7` to latest.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The following [reusable workflows](https://docs.github.com/en/actions/using-work
 - [`test`](.github/workflows/call-test.yml)
 - [`release-pr`](.github/workflows/call-release-pr.yml)
 - [`release`](.github/workflows/call-release.yml)
+- [`dependency-review`](.github/workflows/call-dependency-review.yml)
 
 Usage:
 
@@ -48,6 +49,9 @@ jobs:
     # Specify values different from the defaults.
     # with:
     #   publish: false
+
+  dependency-review:
+    uses: stylelint/.github/.github/workflows/call-dependency-review.yml@d8a0a5b9734a79a67803d47b9aa93e31252a0459 # 0.1.0
 ```
 
 ### Release workflow

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ jobs:
     #   publish: false
 
   dependency-review:
+    if: github.event_name == 'pull_request'
     uses: stylelint/.github/.github/workflows/call-dependency-review.yml@d8a0a5b9734a79a67803d47b9aa93e31252a0459 # 0.1.0
 ```
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This aims to prevent pull requests from being merged if they try to install vulnerable packages.

GitHub's official `actions/dependency-review-action` can supplement dependency auto-updates by Dependabot.

Ref:
- https://github.com/actions/dependency-review-action
- https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/configuring-the-dependency-review-action

