### PR TITLE
Add Node.js v26 to `call-test` default matrix

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -6,7 +6,8 @@ on:
       node-version:
         description: Node.js version
         required: false
-        default: '["20", "22", "24"]' # https://endoflife.date/nodejs
+        # TODO: v20 is already EOL. Drop it. Ref #105
+        default: '["20", "22", "24", "26"]' # https://nodejs.org/en/about/previous-releases
         type: string
       node-version-file:
         description: Node.js version file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Added: Node.js v26 to `call-test` default matrix.
+
 ## 0.7.0 - 2026-04-29
 
 - Added: `call-dependency-review` callable workflow.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Relates #105

> Is there anything in the PR that needs further explanation?

On 2026-05-05, Node.js v26 was out. It will become LTS in this October.

Ref: https://nodejs.org/en/blog/release/v26.0.0
