### PR TITLE
Add `node-version-file` input to `call-lint`/`call-release`/`call-release-pr` workflows

### DIFF
--- a/.github/workflows/call-lint.yml
+++ b/.github/workflows/call-lint.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: 'lts/*'
         type: string
+      node-version-file:
+        description: Node.js version file (takes priority over `node-version` if specified)
+        required: false
+        default: ''
+        type: string
       os:
         description: OS name
         required: false
@@ -16,7 +21,7 @@ on:
 
 jobs:
   lint:
-    name: Lint on Node.js ${{ inputs.node-version }} and ${{ inputs.os }}
+    name: Lint on Node.js ${{ inputs.node-version-file || inputs.node-version }} and ${{ inputs.os }}
 
     runs-on: ${{ inputs.os }}
 
@@ -33,10 +38,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Node.js ${{ inputs.node-version }}
+      - name: Set up Node.js ${{ inputs.node-version-file || inputs.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version: ${{ case(!inputs.node-version-file, inputs.node-version, '') }}
+          node-version-file: ${{ inputs.node-version-file }}
           cache: npm
 
       - name: Install latest npm

--- a/.github/workflows/call-release-pr.yml
+++ b/.github/workflows/call-release-pr.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: 'lts/*'
         type: string
+      node-version-file:
+        description: Node.js version file (takes priority over `node-version` if specified)
+        required: false
+        default: ''
+        type: string
       published-url:
         description: URL where the package will be published. By default, a npm package URL is constructed.
         required: false
@@ -51,10 +56,11 @@ jobs:
         with:
           fetch-depth: 0 # Commit history may be required, such as changelog generation etc.
 
-      - name: Set up Node.js ${{ inputs.node-version }}
+      - name: Set up Node.js ${{ inputs.node-version-file || inputs.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version: ${{ case(!inputs.node-version-file, inputs.node-version, '') }}
+          node-version-file: ${{ inputs.node-version-file }}
           cache: npm
 
       - name: Install latest npm

--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: 'lts/*'
         type: string
+      node-version-file:
+        description: Node.js version file (takes priority over `node-version` if specified)
+        required: false
+        default: ''
+        type: string
     secrets:
       # NOTE: If publishing via OIDC is available, this secret may not be required.
       # Ref https://github.com/microsoft/vscode-vsce/issues/1133
@@ -68,10 +73,11 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Node.js ${{ inputs.node-version }}
+      - name: Set up Node.js ${{ inputs.node-version-file || inputs.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version: ${{ case(!inputs.node-version-file, inputs.node-version, '') }}
+          node-version-file: ${{ inputs.node-version-file }}
           registry-url: 'https://registry.npmjs.org'
           cache: npm
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ jobs:
   lint:
     uses: ./.github/workflows/call-lint.yml
 
+  lint-node-version-file:
+    uses: ./.github/workflows/call-lint.yml
+    with:
+      node-version-file: .node-version
+
   test:
     uses: ./.github/workflows/call-test.yml
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Added: `node-version-file` input to `call-lint`/`call-release`/`call-release-pr` workflows.
+
 ## 0.8.0 - 2026-05-06
 
 - Added: Node.js v26 to `call-test` default matrix.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ jobs:
     uses: stylelint/.github/.github/workflows/call-lint.yml@d8a0a5b9734a79a67803d47b9aa93e31252a0459 # 0.1.0
     # Specify values different from the defaults.
     # with:
-    #   node-version: 18
+    #   node-version: '18'
+    #   node-version-file: .node-version
     #   os: macos-latest
 
   test:
@@ -35,6 +36,7 @@ jobs:
     # Specify values different from the defaults. Need to pass a JSON string.
     # with:
     #   node-version: '["16", "18"]'
+    #   node-version-file: .node-version
     #   os: '["ubuntu-latest", "windows-latest"]'
     #   exclude: '[{"node-version": "16", "os": "windows-latest"}]'
     #   test-options: '--foo --bar'
@@ -43,11 +45,16 @@ jobs:
     uses: stylelint/.github/.github/workflows/call-release-pr.yml@d8a0a5b9734a79a67803d47b9aa93e31252a0459 # 0.1.0
     with:
       new-version: ${{ github.event.inputs.new-version }}
+      # Specify values different from the defaults.
+      # node-version: '18'
+      # node-version-file: .node-version
 
   release:
     uses: stylelint/.github/.github/workflows/call-release.yml@d8a0a5b9734a79a67803d47b9aa93e31252a0459 # 0.1.0
     # Specify values different from the defaults.
     # with:
+    #   node-version: '18'
+    #   node-version-file: .node-version
     #   publish: false
 
   dependency-review:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

Like the `call-test` workflow:
https://github.com/stylelint/.github/blob/e5488b8227de8d0dde6f337344068f1a26dbf3b8/.github/workflows/call-test.yml#L12-L16

This input is helpful for `engine-strict=true`, e.g.,
https://github.com/stylelint/stylelint.io/blob/0da272d1825e670d0ae9d1862bde367d3896c804/.npmrc#L2
